### PR TITLE
Bind the receive socket to the catch-all addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mdns-server
 
-Low level Multicast DNS implementation in pure javascript.
+Low level Multicast DNS implementation in pure javascript. This is a fork of [Bryan Nielsen's](@bnielsen1965) version, with a small bug fix.
 
 Based on [multicast-dns](https://github.com/mafintosh/multicast-dns) by Mathias Buus.
 

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports = function (options) {
           rinfo.interface = iface.name;
           mDNS.socketOnMessage(msg, rinfo);
         })
-        .bind(MDNS_PORT, iface.address + (iface.family === 'IPv4' ? '' : '%' + iface.name));
+        .bind(MDNS_PORT, iface.family === 'IPv4' ? '0.0.0.0' : `::%${iface.name}`);
       });
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mdns-server",
-  "version": "1.0.5",
+  "name": "@alcalzone/mdns-server",
+  "version": "1.0.6",
   "description": "Low level Multicast DNS implementation in pure javascript.",
   "main": "index.js",
   "scripts": {
@@ -8,9 +8,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bnielsen1965/mdns-server.git"
+    "url": "git+https://github.com/AlCalzone/mdns-server.git"
   },
   "author": "Bryan Nielsen (@bnielsen1965)",
+  "contributors": [
+    "AlCalzone (d.griesel@gmx.net)"
+  ],
   "license": "MIT",
   "dependencies": {
     "dns-packet": "^1.1.1"


### PR DESCRIPTION
First of all, thanks for this library - it seems to be the only one that allows to detect Tradfri gateways on a variety of networks. `bonjour` and `multicast-dns` both have flaws in this regard.

When mDNSResponder is running on OSX, binding the receive socket to a specific IP address will throw `EADDRINUSE`, even if `reuseAddr` is set to `true`, as can be seen from this rather long bug hunt: https://github.com/AlCalzone/node-tradfri-client/issues/101

The solution seems to be binding the receive socket to the catch-all addresses `0.0.0.0` (IPv4) and `::%<name>` (IPv6) instead.