### PR TITLE
Fix query on IPv6 interface using Mac

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ module.exports = function (options) {
             0,
             message.length,
             MDNS_PORT,
-            (interfaces[ii].family === 'IPv4' ? MDNS_IPV4 : MDNS_IPV6),
+            (interfaces[ii].family === 'IPv4' ? MDNS_IPV4 : MDNS_IPV6 + '%' + interfaces[ii].name),
             function () {
               processInterface(ii + 1);
             }


### PR DESCRIPTION
MacOS requires the IPV6 addresses are 'fully qualified' for the socket to successfully send any queries.

This PR adds the interface name in order for queries to work. Also tested that it still works on Ubuntu after this change.