### PR TITLE
Fix unhandled exception on Linux during bind

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,11 +179,13 @@ module.exports = function (options) {
           type: (iface.family === 'IPv4' ? 'udp4' : 'udp6'),
           reuseAddr: mDNS.config.reuseAddr
         })
-        .once('error', (err) => {
-          emitter.emit('error', err);
-          reject();
+        .on('error', (err) => {
+          if (err.code === 'EADDRNOTAVAIL') {
+            reject();
+          } else {
+            mDNS.socketError(err);
+          }
         })
-        .on('error', mDNS.socketError)
         .on('listening', () => {
           resolve();
         })

--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ module.exports = function (options) {
             0,
             message.length,
             MDNS_PORT,
-            (interfaces[ii].family === 'IPv4' ? MDNS_IPV4 : MDNS_IPV6),
+            (interfaces[ii].family === 'IPv4' ? MDNS_IPV4 : MDNS_IPV6 + '%' + interfaces[ii].name),
             function () {
               processInterface(ii + 1);
             }


### PR DESCRIPTION
If a socket address is unavailable on Linux, an unhandled `EADDRNOTAVAIL` exception can be thrown.

See: https://github.com/nodejs/node-v0.x-archive/issues/4351

This PR updates the socket code to explicitly handle the exception in the `error` event.